### PR TITLE
Enhancement spaczzmatcher in spaczzruler

### DIFF
--- a/src/spaczz/attrs.py
+++ b/src/spaczz/attrs.py
@@ -28,11 +28,13 @@ class SpaczzAttrs:
                 )
                 Token.set_extension("spaczz_ratio", default=None)
                 Token.set_extension("spaczz_counts", default=None)
+                Token.set_extension("spaczz_details", default=None)
 
                 Span.set_extension("spaczz_span", getter=cls.get_spaczz_span)
                 Span.set_extension("spaczz_types", getter=cls.get_span_types)
                 Span.set_extension("spaczz_ratio", getter=cls.get_ratio)
                 Span.set_extension("spaczz_counts", getter=cls.get_counts)
+                Span.set_extension("spaczz_details", getter=cls.get_details)
 
                 Doc.set_extension("spaczz_doc", getter=cls.get_spaczz_doc)
                 Doc.set_extension("spaczz_types", getter=cls.get_doc_types)
@@ -77,6 +79,8 @@ class SpaczzAttrs:
             types.add("fuzzy")
         if token._.spaczz_counts:
             types.add("regex")
+        if token._.spaczz_details:
+            types.add("token")
         return types
 
     @classmethod
@@ -87,6 +91,8 @@ class SpaczzAttrs:
             types.add("fuzzy")
         if cls.get_counts(span):
             types.add("regex")
+        if cls.get_details(span):
+            types.add("token")
         return types
 
     @classmethod
@@ -102,6 +108,14 @@ class SpaczzAttrs:
         """Getter for spaczz_counts `Span` attribute."""
         if cls._all_equal([token._.spaczz_counts for token in span]):
             return span[0]._.spaczz_counts
+        else:
+            return None
+
+    @classmethod
+    def get_details(cls: Type[T], span: Span) -> Optional[int]:
+        """Getter for current placeholder spaczz_details `Span` attribute."""
+        if cls._all_equal([token._.spaczz_details for token in span]):
+            return span[0]._.spaczz_details
         else:
             return None
 

--- a/src/spaczz/attrs.py
+++ b/src/spaczz/attrs.py
@@ -40,9 +40,8 @@ class SpaczzAttrs:
             except ValueError:
                 warnings.warn(
                     """One or more spaczz custom extensions has already been registered.
-                    These are being force overwritten.
-                    Please avoid defining personal custom extensions
-                    prepended with "spaczz_."
+                    These are being force overwritten. Please avoid defining personal,
+                    custom extensions prepended with "spaczz_".
                 """,
                     AttrOverwriteWarning,
                 )

--- a/src/spaczz/matcher/__init__.py
+++ b/src/spaczz/matcher/__init__.py
@@ -3,12 +3,12 @@ from ._phrasematcher import _PhraseMatcher
 from .fuzzymatcher import FuzzyMatcher
 from .regexmatcher import RegexMatcher
 from .similaritymatcher import SimilarityMatcher
-from .spaczzmatcher import SpaczzMatcher
+from .tokenmatcher import TokenMatcher
 
 __all__ = [
     "_PhraseMatcher",
     "FuzzyMatcher",
     "RegexMatcher",
     "SimilarityMatcher",
-    "SpaczzMatcher",
+    "TokenMatcher",
 ]

--- a/src/spaczz/matcher/tokenmatcher.py
+++ b/src/spaczz/matcher/tokenmatcher.py
@@ -1,4 +1,4 @@
-"""Module for SpaczzMatcher with an API semi-analogous to spaCy's Matcher."""
+"""Module for TokenMatcher with an API semi-analogous to spaCy's Matcher."""
 from __future__ import annotations
 
 from collections import defaultdict
@@ -23,7 +23,7 @@ from spacy.vocab import Vocab
 from ..search import TokenSearcher
 
 
-class SpaczzMatcher:
+class TokenMatcher:
     """spaCy-like token matcher for finding flexible matches in `Doc` objects.
 
     Matches added patterns against the `Doc` object it is called on.
@@ -51,7 +51,7 @@ class SpaczzMatcher:
             Patterns added to the matcher.
     """
 
-    name = "spaczz_matcher"
+    name = "token_matcher"
 
     def __init__(self, vocab: Vocab, **defaults: Any) -> None:
         """Initializes the base phrase matcher with the given defaults.
@@ -69,12 +69,12 @@ class SpaczzMatcher:
                 See `TokenSearcher.match()` documentation for details.
         """
         self.defaults = defaults
-        self.type = "spaczz"
+        self.type = "token"
         self._callbacks: Dict[
             str,
             Union[
                 Callable[
-                    [SpaczzMatcher, Doc, int, List[Tuple[str, int, int, None]]], None
+                    [TokenMatcher, Doc, int, List[Tuple[str, int, int, None]]], None
                 ],
                 None,
             ],
@@ -94,9 +94,9 @@ class SpaczzMatcher:
 
         Example:
             >>> import spacy
-            >>> from spaczz.matcher import SpaczzMatcher
+            >>> from spaczz.matcher import TokenMatcher
             >>> nlp = spacy.blank("en")
-            >>> matcher = SpaczzMatcher(nlp.vocab)
+            >>> matcher = TokenMatcher(nlp.vocab)
             >>> doc = nlp("Rdley Scot was the director of Alien.")
             >>> matcher.add("NAME", [
                 [{"TEXT": {"FUZZY": "Ridley"}},
@@ -142,9 +142,9 @@ class SpaczzMatcher:
 
         Example:
             >>> import spacy
-            >>> from spaczz.matcher import SpaczzMatcher
+            >>> from spaczz.matcher import TokenMatcher
             >>> nlp = spacy.blank("en")
-            >>> matcher = SpaczzMatcher(nlp.vocab)
+            >>> matcher = TokenMatcher(nlp.vocab)
             >>> matcher.add("AUTHOR", [[{"TEXT": {"FUZZY": "Kerouac"}}]])
             >>> matcher.labels
             ('AUTHOR',)
@@ -160,15 +160,15 @@ class SpaczzMatcher:
 
         Example:
             >>> import spacy
-            >>> from spaczz.matcher import SpaczzMatcher
+            >>> from spaczz.matcher import TokenMatcher
             >>> nlp = spacy.blank("en")
-            >>> matcher = SpaczzMatcher(nlp.vocab)
+            >>> matcher = TokenMatcher(nlp.vocab)
             >>> matcher.add("AUTHOR", [[{"TEXT": {"FUZZY": "Kerouac"}}]])
             >>> matcher.patterns == [
                 {
                     "label": "AUTHOR",
                     "pattern": [{"TEXT": {"FUZZY": "Kerouac"}}],
-                    "type": "spaczz",
+                    "type": "token",
                     },
                     ]
             True
@@ -190,7 +190,7 @@ class SpaczzMatcher:
         label: str,
         patterns: List[List[Dict[str, Any]]],
         on_match: Optional[
-            Callable[[SpaczzMatcher, Doc, int, List[Tuple[str, int, int, None]]], None]
+            Callable[[TokenMatcher, Doc, int, List[Tuple[str, int, int, None]]], None]
         ] = None,
     ) -> None:
         """Add a rule to the matcher, consisting of a label and one or more patterns.
@@ -220,9 +220,9 @@ class SpaczzMatcher:
 
         Example:
             >>> import spacy
-            >>> from spaczz.matcher import SpaczzMatcher
+            >>> from spaczz.matcher import TokenMatcher
             >>> nlp = spacy.blank("en")
-            >>> matcher = SpaczzMatcher(nlp.vocab)
+            >>> matcher = TokenMatcher(nlp.vocab)
             >>> matcher.add("AUTHOR", [[{"TEXT": {"FUZZY": "Kerouac"}}]])
             >>> "AUTHOR" in matcher
             True
@@ -247,9 +247,9 @@ class SpaczzMatcher:
 
         Example:
             >>> import spacy
-            >>> from spaczz.matcher import SpaczzMatcher
+            >>> from spaczz.matcher import TokenMatcher
             >>> nlp = spacy.blank("en")
-            >>> matcher = SpaczzMatcher(nlp.vocab)
+            >>> matcher = TokenMatcher(nlp.vocab)
             >>> matcher.add("AUTHOR", [[{"TEXT": {"FUZZY": "Kerouac"}}]])
             >>> matcher.remove("AUTHOR")
             >>> "AUTHOR" in matcher
@@ -289,9 +289,9 @@ class SpaczzMatcher:
 
         Example:
             >>> import spacy
-            >>> from spaczz.matcher import SpaczzMatcher
+            >>> from spaczz.matcher import TokenMatcher
             >>> nlp = spacy.blank("en")
-            >>> matcher = SpaczzMatcher(nlp.vocab)
+            >>> matcher = TokenMatcher(nlp.vocab)
             >>> doc_stream = (
                     nlp("test doc1: Korvld"),
                     nlp("test doc2: Prosh"),

--- a/src/spaczz/pipeline/spaczzruler.py
+++ b/src/spaczz/pipeline/spaczzruler.py
@@ -19,7 +19,7 @@ DEFAULT_ENT_ID_SEP = "||"
 
 
 class SpaczzRuler:
-    """The SpaczzRuler adds fuzzy and multi-token regex matches to spaCy Doc.ents.
+    """The SpaczzRuler adds fuzzy and multi-token regex matches to spaCy `Doc.ents`.
 
     It can be combined with other spaCy NER components like the statistical
     EntityRecognizer and/or the EntityRuler to boost accuracy.

--- a/src/spaczz/pipeline/spaczzruler.py
+++ b/src/spaczz/pipeline/spaczzruler.py
@@ -11,7 +11,7 @@ from spacy.tokens import Doc, Span
 import srsly
 
 from ..exceptions import PatternTypeWarning
-from ..matcher import FuzzyMatcher, RegexMatcher
+from ..matcher import FuzzyMatcher, RegexMatcher, TokenMatcher
 from ..util import ensure_path, read_from_disk, write_to_disk
 
 
@@ -30,21 +30,19 @@ class SpaczzRuler:
         nlp: The shared nlp object to pass the vocab to the matchers
             (not currently used by spaczz matchers) and process fuzzy patterns.
         fuzzy_patterns:
-            Patterns added to the matcher. Contains patterns
-            and kwargs that should be passed to matching function
-            for each labels added.
+            Patterns added to the fuzzy matcher.
         regex_patterns:
-            Patterns added to the matcher. Contains patterns
-            and kwargs that should be passed to matching function
-            for each labels added.
-        defaults: Kwargs to be used as
-            default matching settings for the matchers.
-            See FuzzySearcher and RegexSearcher documentation
-            for kwarg details.
-        fuzzy_matcher: The FuzzyMatcher instance
-            the SpaczzRuler will use for fuzzy matching.
-        regex_matcher: The RegexMatcher instance
-            the SpaczzRuler will use for regex matching.
+            Patterns added to the regex matcher.
+        token_patterns:
+            Patterns added to the token matcher
+        defaults: Default matching settings for their respective matchers.
+            Details to be updated.
+        fuzzy_matcher: The `FuzzyMatcher` instance
+            the spaczz ruler will use for fuzzy phrase matching.
+        regex_matcher: The `RegexMatcher` instance
+            the spaczz ruler will use for regex phrase matching.
+        token_matcher: The `TokenMatcher` instance
+            the spaczz ruler will use for token matching.
     """
 
     name = "spaczz_ruler"
@@ -52,11 +50,15 @@ class SpaczzRuler:
     def __init__(self, nlp: Language, **cfg: Any) -> None:
         """Initialize the spaczz ruler with a Language object and cfg parameters.
 
-        All spaczz ruler cfg parameters are prepended with "spaczz_".
-        If spaczz_patterns is supplied here, they need to be a list of spaczz patterns:
-        dictionaries with a "label", "pattern", "type", and optional "kwargs" key.
-        For example:
-        {'label': 'ORG', 'pattern': 'Apple', 'type': 'fuzzy', 'kwargs': {'min_r2': 90}}.
+        All spaczz ruler cfg parameters are prepended with `"spaczz_"`.
+        If `spaczz_patterns` is supplied here, they need to be a list of
+        spaczz patterns: dictionaries with "label", "pattern", and "type" keys,
+        and if the patterns are fuzzy or regex phrase patterns they can
+        include the optional "kwargs" keys.
+        For example, a fuzzy phrase pattern:
+        {'label': 'ORG', 'pattern': 'Apple', 'type': 'fuzzy', 'kwargs': {'min_r2': 90}}
+        Or, a token pattern:
+        {'label': 'ORG', 'pattern': [{'TEXT': {'FUZZY': 'Apple'}}], 'type': 'spaczz'}
 
 
         Args:
@@ -75,15 +77,17 @@ class SpaczzRuler:
                         utilizing defaults.
                     `regex_defaults` (Dict[str, Any]): Modified default parameters to
                         use with the regex matcher. Default is an empty dictionary -
-                        utilizing defaults. See RegexMatcher/RegexSearcher documentation
-                        for parameter details.
+                        utilizing defaults.
+                    `token_defaults` (Dict[str, Any]): Modified default parameters to
+                        use with the spaczz matcher. Default is an empty dictionary -
+                        utilizing defaults.
                     `regex_config` (Union[str, RegexConfig]): Config to use with the
                         regex matcher. Default is "default".
                         See RegexMatcher/RegexSearcher documentation for available
                         parameter details.
                     `patterns` (Iterable[Dict[str, Any]]): Patterns to initialize
                         the ruler with. Default is None.
-                If SpaczzRuler is loaded as part of a model pipeline,
+                If the spaczz ruler is loaded as part of a model pipeline,
                 cfg will include all keyword arguments passed to `spacy.load()`.
 
         Raises:
@@ -96,10 +100,17 @@ class SpaczzRuler:
         self.regex_patterns: DefaultDict[str, DefaultDict[str, Any]] = defaultdict(
             lambda: defaultdict(list)
         )
+        self.token_patterns: DefaultDict[str, List[List[Dict[str, Any]]]] = defaultdict(
+            list
+        )
         self.ent_id_sep = cfg.get("spaczz_ent_id_sep", DEFAULT_ENT_ID_SEP)
         self._ent_ids: Dict[Any, Any] = defaultdict(dict)
         self.overwrite = cfg.get("spaczz_overwrite_ents", False)
-        default_names = ("spaczz_fuzzy_defaults", "spaczz_regex_defaults")
+        default_names = (
+            "spaczz_fuzzy_defaults",
+            "spaczz_regex_defaults",
+            "spacy_token_defaults",
+        )
         self.defaults = {}
         for name in default_names:
             if name in cfg:
@@ -119,6 +130,9 @@ class SpaczzRuler:
             nlp.vocab,
             cfg.get("spaczz_regex_config", "default"),
             **self.defaults.get("spaczz_regex_defaults", {}),
+        )
+        self.token_matcher = TokenMatcher(
+            nlp.vocab, **self.defaults.get("spaczz_token_defaults", {})
         )
         patterns = cfg.get("spaczz_patterns")
         if patterns is not None:
@@ -161,7 +175,12 @@ class SpaczzRuler:
             best_counts = counts_lookup.get(regex_match[:3])
             if not best_counts or sum(current_counts) < sum(best_counts):
                 counts_lookup[regex_match[:3]] = current_counts
-        matches = fuzzy_matches + regex_matches
+        token_matches = []
+        details_lookup: Dict[Tuple[str, int, int], int] = {}
+        for token_match in self.token_matcher(doc):
+            token_matches.append(token_match[:3])
+            details_lookup[token_match[:3]] = 1
+        matches = fuzzy_matches + regex_matches + token_matches
         unique_matches = set(
             [(match_id, start, end) for match_id, start, end in matches if start != end]
         )
@@ -185,7 +204,13 @@ class SpaczzRuler:
                 else:
                     span = Span(doc, start, end, label=match_id)
                 span = self._update_custom_attrs(
-                    span, match_id, start, end, ratio_lookup, counts_lookup
+                    span,
+                    match_id,
+                    start,
+                    end,
+                    ratio_lookup,
+                    counts_lookup,
+                    details_lookup,
                 )
                 new_entities.append(span)
                 entities = [
@@ -197,13 +222,18 @@ class SpaczzRuler:
 
     def __contains__(self, label: str) -> bool:
         """Whether a label is present in the patterns."""
-        return label in self.fuzzy_patterns or label in self.regex_patterns
+        return (
+            label in self.fuzzy_patterns
+            or label in self.regex_patterns
+            or label in self.token_patterns
+        )
 
     def __len__(self) -> int:
         """The number of all patterns added to the ruler."""
         n_fuzzy_patterns = sum(len(p["patterns"]) for p in self.fuzzy_patterns.values())
         n_regex_patterns = sum(len(p["patterns"]) for p in self.regex_patterns.values())
-        return n_fuzzy_patterns + n_regex_patterns
+        n_token_patterns = sum(len(p) for p in self.token_patterns.values())
+        return n_fuzzy_patterns + n_regex_patterns + n_token_patterns
 
     @property
     def ent_ids(self) -> Tuple[Optional[str], ...]:
@@ -224,6 +254,7 @@ class SpaczzRuler:
         """
         keys = set(self.fuzzy_patterns.keys())
         keys.update(self.regex_patterns.keys())
+        keys.update(self.token_patterns.keys())
         all_ent_ids = set()
 
         for k in keys:
@@ -252,6 +283,7 @@ class SpaczzRuler:
         """
         keys = set(self.fuzzy_patterns.keys())
         keys.update(self.regex_patterns.keys())
+        keys.update(self.token_patterns.keys())
         all_labels = set()
         for k in keys:
             if self.ent_id_sep in k:
@@ -286,21 +318,32 @@ class SpaczzRuler:
             True
         """
         all_patterns = []
-        for label, patterns in self.fuzzy_patterns.items():
-            for pattern, kwargs in zip(patterns["patterns"], patterns["kwargs"]):
+        for label, fuzzy_patterns in self.fuzzy_patterns.items():
+            for fuzzy_pattern, fuzzy_kwargs in zip(
+                fuzzy_patterns["patterns"], fuzzy_patterns["kwargs"]
+            ):
                 ent_label, ent_id = self._split_label(label)
-                p = {"label": ent_label, "pattern": pattern.text, "type": "fuzzy"}
-                if kwargs:
-                    p["kwargs"] = kwargs
+                p = {"label": ent_label, "pattern": fuzzy_pattern.text, "type": "fuzzy"}
+                if fuzzy_kwargs:
+                    p["kwargs"] = fuzzy_kwargs
                 if ent_id:
                     p["id"] = ent_id
                 all_patterns.append(p)
-        for label, patterns in self.regex_patterns.items():
-            for pattern, kwargs in zip(patterns["patterns"], patterns["kwargs"]):
+        for label, regex_patterns in self.regex_patterns.items():
+            for regex_pattern, regex_kwargs in zip(
+                regex_patterns["patterns"], regex_patterns["kwargs"]
+            ):
                 ent_label, ent_id = self._split_label(label)
-                p = {"label": ent_label, "pattern": pattern, "type": "regex"}
-                if kwargs:
-                    p["kwargs"] = kwargs
+                p = {"label": ent_label, "pattern": regex_pattern, "type": "regex"}
+                if regex_kwargs:
+                    p["kwargs"] = regex_kwargs
+                if ent_id:
+                    p["id"] = ent_id
+                all_patterns.append(p)
+        for label, token_patterns in self.token_patterns.items():
+            for token_pattern in token_patterns:
+                ent_label, ent_id = self._split_label(label)
+                p = {"label": ent_label, "pattern": token_pattern, "type": "token"}
                 if ent_id:
                     p["id"] = ent_id
                 all_patterns.append(p)
@@ -310,15 +353,16 @@ class SpaczzRuler:
         """Add patterns to the ruler.
 
         A pattern must be a spaczz pattern:
-        {label (str), pattern (str), type (str),
-        optional kwargs (Dict[str, Any]), and optional id (stry)}.
-        For example:
-        {"label": "ORG", "pattern": "Apple", "type": "fuzzy", "kwargs": {"min_r2": 90}}
+        {label (str), pattern (str or list), type (str),
+        optional kwargs (Dict[str, Any]), and optional id (str)}.
+        For example, a fuzzy phrase pattern:
+        {'label': 'ORG', 'pattern': 'Apple', 'type': 'fuzzy', 'kwargs': {'min_r2': 90}}
+        Or, a token pattern:
+        {'label': 'ORG', 'pattern': [{'TEXT': {'FUZZY': 'Apple'}}], 'type': 'spaczz'}
 
         To utilize regex flags, use inline flags.
 
-        See FuzzyMatcher/FuzzySearcher and RegexMatcher/RegexSearcher documentation
-        for details on available kwargs.
+        Kwarg details to be updated.
 
         Args:
             patterns: The spaczz patterns to add.
@@ -349,6 +393,7 @@ class SpaczzRuler:
             subsequent_pipes = []
 
         with self.nlp.disable_pipes(subsequent_pipes):
+            token_patterns = []
             fuzzy_pattern_labels = []
             fuzzy_pattern_texts = []
             fuzzy_pattern_kwargs = []
@@ -371,20 +416,25 @@ class SpaczzRuler:
                             regex_pattern_texts.append(entry["pattern"])
                             regex_pattern_kwargs.append(entry.get("kwargs", {}))
                             regex_pattern_ids.append(entry.get("id"))
+                        elif entry["type"] == "token":
+                            token_patterns.append(entry)
                         else:
                             warnings.warn(
-                                f"""Spaczz pattern "type" must be "fuzzy" or "regex",
-                                not {entry["label"]}. Skipping this pattern.""",
+                                f"""Spaczz pattern "type" must be "fuzzy", "regex",
+                                or "token", not {entry["type"]}. Skipping this pattern.
+                                """,
                                 PatternTypeWarning,
                             )
                     else:
-                        raise TypeError(("Patterns must be an iterable of dicts."))
+                        raise TypeError(
+                            ("Patterns must either be an iterable of dicts.")
+                        )
                 except KeyError:
                     raise ValueError(
                         (
                             "One or more patterns do not conform",
-                            "to spaczz pattern structure:",
-                            "{label (str), pattern (str), type (str),",
+                            "to spaczz pattern structure: ",
+                            "{label (str), pattern (str or list), type (str),",
                             "optional kwargs (Dict[str, Any]),",
                             "and optional id (str)}.",
                         )
@@ -424,41 +474,46 @@ class SpaczzRuler:
                     regex_pattern["id"] = ent_id
                 regex_patterns.append(regex_pattern)
 
-            self._add_patterns(fuzzy_patterns, regex_patterns)
+            self._add_patterns(fuzzy_patterns, regex_patterns, token_patterns)
 
     def _add_patterns(
-        self, fuzzy_patterns: List[Dict[str, Any]], regex_patterns: List[Dict[str, Any]]
+        self,
+        fuzzy_patterns: List[Dict[str, Any]],
+        regex_patterns: List[Dict[str, Any]],
+        token_patterns: List[Dict[str, Any]],
     ) -> None:
         """Helper function for add_patterns."""
-        for entry in fuzzy_patterns + regex_patterns:
+        for entry in fuzzy_patterns + regex_patterns + token_patterns:
             label = entry["label"]
             if "id" in entry:
                 ent_label = label
                 label = self._create_label(label, entry["id"])
                 self._ent_ids[label] = (ent_label, entry["id"])
             pattern = entry["pattern"]
-            kwargs = entry["kwargs"]
             if isinstance(pattern, Doc):
                 self.fuzzy_patterns[label]["patterns"].append(pattern)
-                self.fuzzy_patterns[label]["kwargs"].append(kwargs)
+                self.fuzzy_patterns[label]["kwargs"].append(entry["kwargs"])
             elif isinstance(pattern, str):
                 self.regex_patterns[label]["patterns"].append(pattern)
-                self.regex_patterns[label]["kwargs"].append(kwargs)
+                self.regex_patterns[label]["kwargs"].append(entry["kwargs"])
+            elif isinstance(pattern, list):
+                self.token_patterns[label].append(pattern)
             else:
                 raise ValueError(
                     (
                         "One or more patterns do not conform",
                         "to spaczz pattern structure:",
-                        "{label (str), pattern (str), type (str),",
+                        "{label (str), pattern (str or list), type (str),",
                         "optional kwargs (Dict[str, Any]),",
                         "and optional id (str)}.",
                     )
                 )
-
-        for label, pattern in self.fuzzy_patterns.items():
-            self.fuzzy_matcher.add(label, pattern["patterns"], pattern["kwargs"])
-        for label, pattern in self.regex_patterns.items():
-            self.regex_matcher.add(label, pattern["patterns"], pattern["kwargs"])
+        for label, patterns in self.fuzzy_patterns.items():
+            self.fuzzy_matcher.add(label, patterns["patterns"], patterns["kwargs"])
+        for label, patterns in self.regex_patterns.items():
+            self.regex_matcher.add(label, patterns["patterns"], patterns["kwargs"])
+        for label, _token_patterns in self.token_patterns.items():
+            self.token_matcher.add(label, _token_patterns)
 
     def from_bytes(self, patterns_bytes: bytes, **kwargs: Any) -> SpaczzRuler:
         """Load the spaczz ruler from a bytestring.
@@ -651,12 +706,15 @@ class SpaczzRuler:
         end: int,
         ratio_lookup: Dict[Tuple[str, int, int], int],
         counts_lookup: Dict[Tuple[str, int, int], Tuple[int, int, int]],
+        details_lookup: Dict[Tuple[str, int, int], int],
     ) -> Span:
         """Update custom attributes for matches."""
         ratio = ratio_lookup.get((match_id, start, end), None)
         counts = counts_lookup.get((match_id, start, end), None)
+        details = details_lookup.get((match_id, start, end), None)
         for token in span:
             token._.spaczz_token = True
             token._.spaczz_ratio = ratio
             token._.spaczz_counts = counts
+            token._.spaczz_details = details
         return span

--- a/src/spaczz/search/_phrasesearcher.py
+++ b/src/spaczz/search/_phrasesearcher.py
@@ -305,7 +305,7 @@ class _PhraseSearcher:
                         """,
                     FlexWarning,
                 )
-                flex = len(query)
+                flex = max(len(query) - 1, 0)
         else:
             raise TypeError("Flex must either be the string 'default' or an integer.")
         return flex

--- a/src/spaczz/search/_phrasesearcher.py
+++ b/src/spaczz/search/_phrasesearcher.py
@@ -251,6 +251,8 @@ class _PhraseSearcher:
             A dictionary of start index, match ratio pairs or None.
         """
         match_values: Dict[int, int] = dict()
+        if not len(query):
+            return None
         i = 0
         while i + len(query) <= len(doc):
             match = self.compare(query, doc[i : i + len(query)], *args, **kwargs)
@@ -294,12 +296,13 @@ class _PhraseSearcher:
             1
         """
         if flex == "default":
-            flex = len(query) - 1
+            flex = max(len(query) - 1, 0)
         elif isinstance(flex, int):
             if flex > len(query):
                 warnings.warn(
                     f"""Flex of size {flex} is greater than len(query).\n
-                        Setting flex to the default flex = len(query) - 1.""",
+                        Setting flex to the default flex = max(len(query) - 1, 0).
+                        """,
                     FlexWarning,
                 )
                 flex = len(query)

--- a/src/spaczz/search/_phrasesearcher.py
+++ b/src/spaczz/search/_phrasesearcher.py
@@ -96,7 +96,10 @@ class _PhraseSearcher:
             query: `Doc` object to match against doc.
             flex: Number of tokens to move match span boundaries
                 left and right during match optimization.
-                Default is `"default"` (length of query - 1).
+                Can be an integer value with a max of `len(query)`
+                and a min of 0 (will warn and change if higher or lower),
+                "max", "min", or "default".
+                Default is `"default"`: `max(len(query) - 1, 0)`.
             min_r1: Minimum match ratio required for
                 selection during the intial search over doc.
                 This should be lower than min_r2 and "low" in general
@@ -268,23 +271,32 @@ class _PhraseSearcher:
     def _calc_flex(query: Doc, flex: Union[str, int]) -> int:
         """Returns flex value based on initial value and query.
 
-        By default flex is set to the legth of query - 1.
-        If flex is a value greater than query,
+        By default flex is set to `max(len(query) - 1, 0)`.
+
+        If flex is an integer value greater than `len(query)`,
         flex will be set to `len(query)` instead.
+
+        If flex is an integer value less than 0,
+        flex will be set to 0 instead.
 
         Args:
             query: The `Doc` object to match with.
-            flex: Either `"default"` or an integer value.
+            flex: Either `"default"`: `max(len(query) - 1, 0)`,
+                `"max"`: `len(query)`,
+                `"min"`: `0`,
+                or an integer value.
 
         Returns:
             The new flex value.
 
         Raises:
-            TypeError: If flex is not "default" or an int.
+            TypeError: If flex is not "default", "max", "min", or an int.
 
         Warnings:
             FlexWarning:
                 If flex is > `len(query)`.
+            FlexWarning:
+                If flex is < 0.
 
         Example:
             >>> import spacy
@@ -297,17 +309,32 @@ class _PhraseSearcher:
         """
         if flex == "default":
             flex = max(len(query) - 1, 0)
+        if flex == "max":
+            flex = len(query)
+        if flex == "min":
+            flex = 0
         elif isinstance(flex, int):
             if flex > len(query):
                 warnings.warn(
-                    f"""Flex of size {flex} is greater than len(query).\n
-                        Setting flex to the default flex = max(len(query) - 1, 0).
-                        """,
+                    f"""Flex of size {flex} is greater than len(query).
+                        Setting to the max, `len(query)`, instead.""",
                     FlexWarning,
                 )
-                flex = max(len(query) - 1, 0)
+                flex = len(query)
+            if flex < 0:
+                warnings.warn(
+                    """Flex values less than 0 are not allowed.
+                    Setting flex to the min, 0, instead.""",
+                    FlexWarning,
+                )
+                flex = 0
         else:
-            raise TypeError("Flex must either be the string 'default' or an integer.")
+            raise TypeError(
+                (
+                    "Flex must either be the strings 'default',",
+                    "`max`, or `min`, or an integer.",
+                )
+            )
         return flex
 
     @staticmethod

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -1,4 +1,4 @@
-"""Tests for the spaczzattrs module."""
+"""Tests for the attrs module."""
 import pytest
 from spacy.language import Language
 from spacy.tokens import Doc
@@ -19,13 +19,14 @@ def test_initialize_again_skips() -> None:
     assert SpaczzAttrs._initialized is True
 
 
-def test_get_token_types(nlp: Language) -> None:
+def test_get_token_types(nlp: Language, doc: Doc) -> None:
     """Returns token match types."""
-    doc = nlp("one ent")
     doc[0]._.spaczz_counts = (0, 0, 0)
     doc[1]._.spaczz_ratio = 100
+    doc[2]._.spaczz_details = 1
     assert doc[0]._.spaczz_types == {"regex"}
     assert doc[1]._.spaczz_types == {"fuzzy"}
+    assert doc[2]._.spaczz_types == {"token"}
 
 
 def test_get_spaczz_span(doc: Doc) -> None:
@@ -37,24 +38,32 @@ def test_get_spaczz_span(doc: Doc) -> None:
 
 def test_get_span_types1(doc: Doc) -> None:
     """Returns span match types."""
-    for token in doc[:2]:
+    for token in doc[:3]:
         token._.spaczz_ratio = 100
         token._.spaczz_counts = (0, 0, 0)
-    assert doc[:2]._.spaczz_types == {"regex", "fuzzy"}
+        token._.spaczz_details = 1
+    assert doc[:3]._.spaczz_types == {"regex", "fuzzy", "token"}
 
 
 def test_get_span_types2(doc: Doc) -> None:
     """Returns span match types."""
-    for token in doc[:2]:
+    for token in doc[:3]:
         token._.spaczz_ratio = 100
-    assert doc[:2]._.spaczz_types == {"fuzzy"}
+    assert doc[:3]._.spaczz_types == {"fuzzy"}
 
 
 def test_get_span_types3(doc: Doc) -> None:
     """Returns span match types."""
-    for token in doc[:2]:
+    for token in doc[:3]:
         token._.spaczz_counts = (0, 0, 0)
-    assert doc[:2]._.spaczz_types == {"regex"}
+    assert doc[:3]._.spaczz_types == {"regex"}
+
+
+def test_get_span_types4(doc: Doc) -> None:
+    """Returns span match types."""
+    for token in doc[:3]:
+        token._.spaczz_details = 1
+    assert doc[:3]._.spaczz_types == {"token"}
 
 
 def test_get_ratio1(doc: Doc) -> None:
@@ -85,6 +94,20 @@ def test_get_counts2(doc: Doc) -> None:
     assert doc[:2]._.spaczz_counts is None
 
 
+def test_get_details1(doc: Doc) -> None:
+    """Returns span details."""
+    for token in doc[:2]:
+        token._.spaczz_details = 1
+    assert doc[:2]._.spaczz_details == 1
+
+
+def test_get_details2(doc: Doc) -> None:
+    """Returns span details."""
+    doc[0]._.spaczz_details = 1
+    doc[1]._.spaczz_counts = (0, 0, 0)
+    assert doc[:2]._.spaczz_details is None
+
+
 def test_get_spaczz_doc(doc: Doc) -> None:
     """Returns spaczz doc boolean."""
     for token in doc[:2]:
@@ -96,7 +119,8 @@ def test_get_doc_types(doc: Doc) -> None:
     """Returns doc match types."""
     doc[0]._.spaczz_ratio = 100
     doc[1]._.spaczz_counts = (0, 0, 0)
-    assert doc._.spaczz_types == {"fuzzy", "regex"}
+    doc[2]._.spaczz_details = 1
+    assert doc._.spaczz_types == {"fuzzy", "regex", "token"}
 
 
 def test_init_w_duplicate_custom_attrs_warns() -> None:

--- a/tests/test_matcher/test_tokenmatcher.py
+++ b/tests/test_matcher/test_tokenmatcher.py
@@ -1,15 +1,15 @@
-"""Tests for spaczzmatcher module."""
+"""Tests for tokenmatcher module."""
 from typing import List, Tuple
 
 import pytest
 from spacy.language import Language
 from spacy.tokens import Doc, Span
 
-from spaczz.matcher import SpaczzMatcher
+from spaczz.matcher import TokenMatcher
 
 
 def add_name_ent(
-    matcher: SpaczzMatcher, doc: Doc, i: int, matches: List[Tuple[str, int, int, None]]
+    matcher: TokenMatcher, doc: Doc, i: int, matches: List[Tuple[str, int, int, None]]
 ) -> None:
     """Callback on match function. Adds "NAME" entities to doc."""
     _match_id, start, end, _ = matches[i]
@@ -18,9 +18,9 @@ def add_name_ent(
 
 
 @pytest.fixture
-def matcher(model: Language) -> SpaczzMatcher:
-    """It returns a spaczz matcher."""
-    matcher = SpaczzMatcher(vocab=model.vocab)
+def matcher(model: Language) -> TokenMatcher:
+    """It returns a token matcher."""
+    matcher = TokenMatcher(vocab=model.vocab)
     matcher.add(
         "DATA",
         [
@@ -46,7 +46,7 @@ def example(model: Language) -> Doc:
     )
 
 
-def test_adding_patterns(matcher: SpaczzMatcher) -> None:
+def test_adding_patterns(matcher: TokenMatcher) -> None:
     """It adds the "TEST" label and some patterns to the matcher."""
     assert matcher.patterns == [
         {
@@ -56,54 +56,54 @@ def test_adding_patterns(matcher: SpaczzMatcher) -> None:
                 {"LOWER": {"FREGEX": "(database){s<=1}"}},
                 {"LOWER": {"FUZZY": "access"}, "POS": "NOUN"},
             ],
-            "type": "spaczz",
+            "type": "token",
         },
         {
             "label": "DATA",
             "pattern": [{"TEXT": {"FUZZY": "Sequel"}}, {"LOWER": "db"}],
-            "type": "spaczz",
+            "type": "token",
         },
         {
             "label": "NAME",
             "pattern": [{"TEXT": {"FUZZY": "Garfield"}}],
-            "type": "spaczz",
+            "type": "token",
         },
     ]
 
 
-def test_add_without_sequence_of_patterns_raises_error(matcher: SpaczzMatcher,) -> None:
+def test_add_without_sequence_of_patterns_raises_error(matcher: TokenMatcher,) -> None:
     """Trying to add non-sequences of patterns raises a TypeError."""
     with pytest.raises(TypeError):
         matcher.add("TEST", [{"TEXT": "error"}])
 
 
-def test_add_with_zero_len_pattern(matcher: SpaczzMatcher) -> None:
+def test_add_with_zero_len_pattern(matcher: TokenMatcher) -> None:
     """Trying to add zero-length patterns raises a ValueError."""
     with pytest.raises(ValueError):
         matcher.add("TEST", [[]])
 
 
-def test_len_returns_count_of_labels_in_matcher(matcher: SpaczzMatcher,) -> None:
+def test_len_returns_count_of_labels_in_matcher(matcher: TokenMatcher,) -> None:
     """It returns the sum of unique labels in the matcher."""
     assert len(matcher) == 2
 
 
-def test_in_returns_bool_of_label_in_matcher(matcher: SpaczzMatcher,) -> None:
+def test_in_returns_bool_of_label_in_matcher(matcher: TokenMatcher,) -> None:
     """It returns whether a label is in the matcher."""
     assert "DATA" in matcher
 
 
-def test_labels_returns_label_names(matcher: SpaczzMatcher) -> None:
+def test_labels_returns_label_names(matcher: TokenMatcher) -> None:
     """It returns a tuple of all unique label names."""
     assert all(label in matcher.labels for label in ("DATA", "NAME"))
 
 
-def test_vocab_prop_returns_vocab(matcher: SpaczzMatcher, model: Language) -> None:
+def test_vocab_prop_returns_vocab(matcher: TokenMatcher, model: Language) -> None:
     """It returns the vocab it was initialized with."""
     assert matcher.vocab == model.vocab
 
 
-def test_remove_label(matcher: SpaczzMatcher) -> None:
+def test_remove_label(matcher: TokenMatcher) -> None:
     """It removes a label from the matcher."""
     matcher.add("TEST", [[{"TEXT": "test"}]])
     assert "TEST" in matcher
@@ -112,14 +112,14 @@ def test_remove_label(matcher: SpaczzMatcher) -> None:
 
 
 def test_remove_label_raises_error_if_label_not_in_matcher(
-    matcher: SpaczzMatcher,
+    matcher: TokenMatcher,
 ) -> None:
     """It raises a ValueError if trying to remove a label not present."""
     with pytest.raises(ValueError):
         matcher.remove("TEST")
 
 
-def test_matcher_returns_matches(matcher: SpaczzMatcher, example: Doc) -> None:
+def test_matcher_returns_matches(matcher: TokenMatcher, example: Doc) -> None:
     """Calling the matcher on a `Doc` object returns matches."""
     assert matcher(example) == [
         ("DATA", 4, 7, None),
@@ -130,7 +130,7 @@ def test_matcher_returns_matches(matcher: SpaczzMatcher, example: Doc) -> None:
 
 def test_matcher_returns_empty_list_if_no_matches(nlp: Language) -> None:
     """Calling the matcher on a `Doc` object with no matches returns empty list."""
-    matcher = SpaczzMatcher(nlp.vocab)
+    matcher = TokenMatcher(nlp.vocab)
     matcher.add("TEST", [[{"TEXT": {"FUZZY": "blah"}}]])
     doc = nlp("No matches here.")
     assert matcher(doc) == []
@@ -138,14 +138,14 @@ def test_matcher_returns_empty_list_if_no_matches(nlp: Language) -> None:
 
 def test_matcher_warns_if_unknown_pattern_elements(nlp: Language) -> None:
     """Calling the matcher on a `Doc` object with no matches returns empty list."""
-    matcher = SpaczzMatcher(nlp.vocab)
+    matcher = TokenMatcher(nlp.vocab)
     matcher.add("TEST", [[{"TEXT": {"fuzzy": "test"}}]])
     doc = nlp("test")
     with pytest.warns(UserWarning):
         matcher(doc)
 
 
-def test_matcher_uses_on_match_callback(matcher: SpaczzMatcher, example: Doc) -> None:
+def test_matcher_uses_on_match_callback(matcher: TokenMatcher, example: Doc) -> None:
     """It utilizes callback on match functions passed when called on a Doc object."""
     matcher(example)
     ent_text = [ent.text for ent in example.ents]
@@ -158,7 +158,7 @@ def test_matcher_pipe(nlp: Language) -> None:
         nlp("test doc 1: Corvold"),
         nlp("test doc 2: Prosh"),
     )
-    matcher = SpaczzMatcher(nlp.vocab)
+    matcher = TokenMatcher(nlp.vocab)
     output = matcher.pipe(doc_stream)
     assert list(output) == list(doc_stream)
 
@@ -169,7 +169,7 @@ def test_matcher_pipe_with_context(nlp: Language) -> None:
         (nlp("test doc 1: Corvold"), "Jund"),
         (nlp("test doc 2: Prosh"), "Jund"),
     )
-    matcher = SpaczzMatcher(nlp.vocab)
+    matcher = TokenMatcher(nlp.vocab)
     output = matcher.pipe(doc_stream, as_tuples=True)
     assert list(output) == list(doc_stream)
 
@@ -180,7 +180,7 @@ def test_matcher_pipe_with_matches(nlp: Language) -> None:
         nlp("test doc 1: Corvold"),
         nlp("test doc 2: Prosh"),
     )
-    matcher = SpaczzMatcher(nlp.vocab)
+    matcher = TokenMatcher(nlp.vocab)
     matcher.add(
         "DRAGON", [[{"TEXT": {"FUZZY": "Korvold"}}], [{"TEXT": {"FUZZY": "Prossh"}}]]
     )
@@ -195,7 +195,7 @@ def test_matcher_pipe_with_matches_and_context(nlp: Language) -> None:
         (nlp("test doc 1: Corvold"), "Jund"),
         (nlp("test doc 2: Prosh"), "Jund"),
     )
-    matcher = SpaczzMatcher(nlp.vocab)
+    matcher = TokenMatcher(nlp.vocab)
     matcher.add(
         "DRAGON", [[{"TEXT": {"FUZZY": "Korvold"}}], [{"TEXT": {"FUZZY": "Prossh"}}]]
     )

--- a/tests/test_search/test_fuzzysearcher.py
+++ b/tests/test_search/test_fuzzysearcher.py
@@ -52,9 +52,21 @@ def test_compare_raises_error_with_unknown_func_name(
 
 
 def test__calc_flex_with_default(nlp: Language, searcher: FuzzySearcher) -> None:
-    """It returns len(query) if set with "default"."""
+    """It returns max(len(query)-1, 0) if set with "default"."""
     query = nlp("Test query")
     assert searcher._calc_flex(query, "default") == 1
+
+
+def test__calc_flex_with_max(nlp: Language, searcher: FuzzySearcher) -> None:
+    """It returns len(query) if set with "max"."""
+    query = nlp("Test query")
+    assert searcher._calc_flex(query, "max") == 2
+
+
+def test__calc_flex_with_min(nlp: Language, searcher: FuzzySearcher) -> None:
+    """It returns 0 if set with "min"."""
+    query = nlp("Test query")
+    assert searcher._calc_flex(query, "min") == 0
 
 
 def test__calc_flex_passes_through_valid_value(
@@ -71,7 +83,18 @@ def test__calc_flex_warns_if_flex_longer_than_query(
     """It provides UserWarning if flex > len(query)."""
     query = nlp("Test query")
     with pytest.warns(FlexWarning):
-        searcher._calc_flex(query, 5)
+        flex = searcher._calc_flex(query, 5)
+        assert flex == 2
+
+
+def test__calc_flex_warns_if_flex_less_than_0(
+    nlp: Language, searcher: FuzzySearcher
+) -> None:
+    """It provides UserWarning if flex < 0."""
+    query = nlp("Test query")
+    with pytest.warns(FlexWarning):
+        flex = searcher._calc_flex(query, -1)
+        assert flex == 0
 
 
 def test__calc_flex_raises_error_if_non_valid_value(
@@ -224,7 +247,7 @@ def test_match_return_empty_list_when_no_matches_after_adjust(
     assert searcher.match(doc, query) == []
 
 
-def test_match_raises_error_when_doc_not_Doc(
+def test_match_raises_error_when_doc_not_doc_obj(
     searcher: FuzzySearcher, nlp: Language
 ) -> None:
     """It raises a TypeError if doc is not a Doc object."""
@@ -234,7 +257,7 @@ def test_match_raises_error_when_doc_not_Doc(
         searcher.match(doc, query)
 
 
-def test_match_raises_error_if_query_not_Doc(
+def test_match_raises_error_if_query_not_doc_obj(
     searcher: FuzzySearcher, nlp: Language
 ) -> None:
     """It raises a TypeError if query not a doc."""

--- a/tests/test_search/test_fuzzysearcher.py
+++ b/tests/test_search/test_fuzzysearcher.py
@@ -168,6 +168,13 @@ def test__optimize_with_no_flex(searcher: FuzzySearcher, nlp: Language) -> None:
     ) == (3, 4, 94)
 
 
+def test__optimize_where_bpl_equal_bpr(searcher: FuzzySearcher, nlp: Language) -> None:
+    """It returns the intial match when flex value = 0."""
+    doc = nlp("trabalho, investimento e escolhas corajosas,")
+    query = nlp("Courtillier Musqué")
+    assert searcher.match(doc, query) == []
+
+
 def test__filter_overlapping_matches_filters_correctly(
     searcher: FuzzySearcher,
 ) -> None:

--- a/tests/test_search/test_fuzzysearcher.py
+++ b/tests/test_search/test_fuzzysearcher.py
@@ -116,6 +116,19 @@ def test__scan_with_no_matches(
     )
 
 
+def test__scan_returns_none_w_empty_query(
+    searcher: FuzzySearcher, nlp: Language, scan_example: Doc
+) -> None:
+    """It returns None if passed an empty query string."""
+    query = nlp("")
+    assert (
+        searcher._scan(
+            scan_example, query, fuzzy_func="simple", min_r1=25, ignore_case=True
+        )
+        is None
+    )
+
+
 def test__optimize_finds_better_match(searcher: FuzzySearcher, nlp: Language) -> None:
     """It optimizes the initial match to find a better match."""
     doc = nlp("Patient was prescribed Zithromax tablets.")
@@ -229,3 +242,30 @@ def test_match_raises_error_if_query_not_Doc(
     query = "Not a doc"
     with pytest.raises(TypeError):
         searcher.match(doc, query)
+
+
+def test_match_returns_empty_list_if_query_empty(
+    searcher: FuzzySearcher, nlp: Language
+) -> None:
+    """Returns empty if query is empty string."""
+    doc = nlp("This is a doc")
+    query = nlp("")
+    assert searcher.match(doc, query) == []
+
+
+def test_match_returns_empty_list_if_doc_empty(
+    searcher: FuzzySearcher, nlp: Language
+) -> None:
+    """Returns empty list if doc is empty string."""
+    doc = nlp("")
+    query = nlp("test")
+    assert searcher.match(doc, query) == []
+
+
+def test_match_returns_empty_list_if_doc_query_empty(
+    searcher: FuzzySearcher, nlp: Language
+) -> None:
+    """Returns empty list if doc is empty string."""
+    doc = nlp("")
+    query = nlp("")
+    assert searcher.match(doc, query) == []


### PR DESCRIPTION
1. SpaczzMatcher is now called TokenMatcher
2. TokenMatcher now part of SpaczzRuler
3. "token" type part of `._.spaczz_types` now and `._.spaczz_details` is placeholder for future token match values.
4. More options for `flex` value.
5. Span out of range bug fix for empty string fuzzy/similarity patterns and catch-all for bp_l >= bp_r and bp_r <= bp_l.