### PR TITLE
BugFix for german Combination words for RegexSearcher

### DIFF
--- a/src/spaczz/search/regexsearcher.py
+++ b/src/spaczz/search/regexsearcher.py
@@ -138,7 +138,7 @@ class RegexSearcher:
             else:
                 if partial:
                     start_token = chars_to_tokens.get(start)
-                    end_token = chars_to_tokens.get(end)
+                    end_token = chars_to_tokens.get(end - 1)
                     if start_token and end_token:
                         span = Span(doc, start_token, end_token + 1)
                         matches.append((span, counts))

--- a/tests/test_search/test_regexsearcher.py
+++ b/tests/test_search/test_regexsearcher.py
@@ -57,6 +57,17 @@ def test_match_will_expand_on_partial_match_if_partials(
     assert matches == [(5, 6, (0, 0, 0))]
 
 
+def test_match_on_german_combination_words(
+    searcher: RegexSearcher, nlp: Language
+) -> None:
+    """It extends partial matches to span boundaries."""
+    doc = nlp(
+        "We want to identify a geman word combination Aussagekraft or Kraftfahrzeug"
+    )
+    matches = searcher.match(doc, "(kraft|Kraft)")
+    assert matches == [(8, 9, (0, 0, 0)), (10, 11, (0, 0, 0))]
+
+
 def test_match_will_not_expand_if_not_partials(
     searcher: RegexSearcher, nlp: Language
 ) -> None:


### PR DESCRIPTION
Hello,

i encountered a bug when searching for a substring inside a string.
When the subword is at the end of the word, it wasn"t found.
e.g. 
```python
text =  "We want to identify a geman word combination Aussagekraft"
doc = nlp(text)
search = RegexSearcher(nlp.vocab)
matches = search.match(doc,r'(kraft|Kraft)') # matches  = []
```


The change should fix the Bug and i also added a Testcase.

