### PR TITLE
Fix several typos in the README, src folder and tests folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The full list of keyword arguments available for fuzzy matching rules includes:
     - Default is `"simple"`.
 - `ignore_case`: If strings should be lower-cased before comparison or not. Default is `True`.
 - `flex`: Number of tokens to move match match boundaries left and right during optimization. Can be an integer value with a max of `len(query)` and a min of `0` (will warn and change if higher or lower),or the strings "max", "min", or "default". Default is `"default"`: `len(query) // 2`.
-- `min_r1`: Minimum match ratio required forselection during the intial search over doc. If `flex == 0`, `min_r1` will be overwritten by `min_r2`. If `flex > 0`, `min_r1` must be lower than `min_r2` and "low" in general because match boundaries are not flexed initially. Default is `50`.
+- `min_r1`: Minimum match ratio required for selection during the initial search over doc. If `flex == 0`, `min_r1` will be overwritten by `min_r2`. If `flex > 0`, `min_r1` must be lower than `min_r2` and "low" in general because match boundaries are not flexed initially. Default is `50`.
 - `min_r2`: Minimum match ratio required for selection during match optimization. Needs to be higher than `min_r1` and "high" in general to ensure only quality matches are returned. Default is `75`.
 - `thresh`: If this ratio is exceeded in initial scan, and `flex > 0`, no optimization will be attempted. If `flex == 0`, `thresh` has no effect. Default is `100`.
 
@@ -296,7 +296,7 @@ Also as a somewhat experimental feature, the similarity matcher is not currently
 The full list of keyword arguments available for similarity matching rules includes:
 
 - `flex`: Number of tokens to move match span boundaries left and right during match optimization. Can be an integer value with a max of `len(query)` and a min of `0` (will warn and change if higher or lower), `"max"`, `"min"`, or `"default"`. Default is `"default"`: `len(query) // 2`.
-- `min_r1`: Minimum similarity match ratio required for selection during the intial search over doc. This should be lower than `min_r2` and "low" in general because match span boundaries are not flexed initially. `0` means all spans of query length in doc will have their boundaries flexed and will be re-compared during match optimization. Lower `min_r1` will result in more fine-grained matching but will run slower. Default is `50`.
+- `min_r1`: Minimum similarity match ratio required for selection during the initial search over doc. This should be lower than `min_r2` and "low" in general because match span boundaries are not flexed initially. `0` means all spans of query length in doc will have their boundaries flexed and will be re-compared during match optimization. Lower `min_r1` will result in more fine-grained matching but will run slower. Default is `50`.
 - `min_r2`: Minimum similarity match ratio required for selection during match optimization. Should be higher than `min_r1` and "high" in general to ensure only quality matches are returned. Default is `75`.
 - `thresh`: If this ratio is exceeded in initial scan no optimization will be attempted. Default is `100`.
 

--- a/src/spaczz/pipeline/_spaczzruler_legacy.py
+++ b/src/spaczz/pipeline/_spaczzruler_legacy.py
@@ -85,7 +85,7 @@ class SpaczzRuler:
                 spaczz config parameters start with "spaczz_" to keep them
                 from colliding with other cfg components.
                 SpaczzRuler cfg components include (with "spaczz_" prepended to them):
-                    `overwrite_ents` (bool): Whether to overwrite exisiting Doc.ents
+                    `overwrite_ents` (bool): Whether to overwrite existing Doc.ents
                         with new matches. Default is False.
                     `ent_id_sep` (str): String to separate entity labels and ids on.
                     `fuzzy_defaults` (dict[str, Any]): Modified default parameters to
@@ -483,7 +483,7 @@ class SpaczzRuler:
         """Serialize the spaczz ruler patterns to a bytestring.
 
         Args:
-            **kwargs: Other config paramters, mostly for consistency.
+            **kwargs: Other config parameters, mostly for consistency.
 
         Returns:
             The serialized patterns.
@@ -508,7 +508,7 @@ class SpaczzRuler:
 
         Args:
             path: The JSONL file to load.
-            **kwargs: Other config paramters, mostly for consistency.
+            **kwargs: Other config parameters, mostly for consistency.
 
         Returns:
             The loaded spaczz ruler.
@@ -552,7 +552,7 @@ class SpaczzRuler:
 
         Args:
             path: The JSONL file to save.
-            **kwargs: Other config paramters, mostly for consistency.
+            **kwargs: Other config parameters, mostly for consistency.
         """
         path = ensure_path(path)
         cfg = {

--- a/src/spaczz/search/_phrasesearcher.py
+++ b/src/spaczz/search/_phrasesearcher.py
@@ -104,7 +104,7 @@ class _PhraseSearcher:
                 or the strings "max", "min", or "default".
                 Default is `"default"`: `len(query) // 2`.
             min_r1: Minimum match ratio required for
-                selection during the intial search over doc.
+                selection during the initial search over doc.
                 If `flex == 0`, `min_r1` will be overwritten by `min_r2`.
                 If `flex > 0`, `min_r1` must be lower than `min_r2`
                 and "low" in general because match boundaries are
@@ -262,7 +262,7 @@ class _PhraseSearcher:
             doc: `Doc` object to search over.
             query: `Doc` object to match against doc.
             min_r1: Minimum match ratio required for
-                selection during the intial search over `doc`.
+                selection during the initial search over `doc`.
                 This should be lower than `min_r2` and "low" in general
                 because match span boundaries are not flexed here.
                 `0` means all spans of query length in doc will

--- a/tests/test_pipeline/test_spaczzruler.py
+++ b/tests/test_pipeline/test_spaczzruler.py
@@ -110,14 +110,14 @@ def lorem(fixtures: Path) -> str:
 
 
 def test_empty_default_ruler(nlp: Language) -> None:
-    """It initialzes an empty ruler."""
+    """It initializes an empty ruler."""
     ruler = SpaczzRuler(nlp)
     assert not ruler.fuzzy_patterns
     assert not ruler.regex_patterns
 
 
 def test_ruler_with_changed_matcher_defaults(nlp: Language) -> None:
-    """It intializes with changed defaults in the matchers."""
+    """It initializes with changed defaults in the matchers."""
     ruler = SpaczzRuler(nlp, spaczz_fuzzy_defaults={"ignore_case": False})
     assert ruler.fuzzy_matcher.defaults == {"ignore_case": False}
 

--- a/tests/test_search/test_fuzzysearcher.py
+++ b/tests/test_search/test_fuzzysearcher.py
@@ -204,7 +204,7 @@ def test__optimize_finds_better_match_with_max_flex(
 
 
 def test__optimize_with_no_flex(searcher: FuzzySearcher, nlp: Language) -> None:
-    """It returns the intial match when flex value = 0."""
+    """It returns the initial match when flex value = 0."""
     doc = nlp("Patient was prescribed Zithroma tablets.")
     query = nlp("zithromax")
     match_values = {3: 94}
@@ -227,7 +227,7 @@ def test__optimize_with_no_flex(searcher: FuzzySearcher, nlp: Language) -> None:
 def test__optimize_where_bpl_would_equal_bpr(
     searcher: FuzzySearcher, nlp: Language
 ) -> None:
-    """It returns the intial match when flex value = 0."""
+    """It returns the initial match when flex value = 0."""
     doc = nlp("trabalho, investimento e escolhas corajosas,")
     query = nlp("Courtillier Musqué")
     assert searcher.match(doc, query, flex="max") == []


### PR DESCRIPTION
Hello!

### Pull request overview
* Fix several typos throughout the project.

---

I was reading through your README and found two typos, leading me to run `codespell` on your codebase to attempt to fix a handful more.
This project is very useful! Great job.

- Tom Aarsen