### PR TITLE
Partial regex matcher doesn't work if the found token has index 0

### DIFF
--- a/src/spaczz/_search/regexsearcher.py
+++ b/src/spaczz/_search/regexsearcher.py
@@ -138,7 +138,7 @@ class RegexSearcher:
         if partial:
             start_token = char_to_token_map.get(start)
             end_token = char_to_token_map.get(end - 1)
-            if start_token and end_token:
+            if start_token is not None and end_token is not None:
                 span = Span(doc, start_token, end_token + 1)
                 return (span, counts)
         return None


### PR DESCRIPTION
Hi, here is a small snippet to reproduce the problem
```
from spaczz.matcher import RegexMatcher
import spacy

nlp = spacy.blank("en")
matcher = RegexMatcher(nlp.vocab)

not_working = "withh something"
working = "something withh"

matcher.add("WITH", ["with"])

print(matcher(nlp(not_working)))
# > before fix []
# > after fix [('WITH', 0, 1, 100, 'with')]

print(matcher(nlp(working)))
# > before fix [('WITH', 1, 2, 100, 'with')]
# > after fix [('WITH', 1, 2, 100, 'with')]
```