### PR TITLE
Updating GH action versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         architecture: x64
@@ -16,7 +16,7 @@ jobs:
     - name: Generate Coverage Report
       run: nox --session "tests-3.11(spacy='3.7.4', rapidfuzz='3.6.2')" -- --cov --cov-report=xml
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml

--- a/.github/workflows/lint-check-test.yml
+++ b/.github/workflows/lint-check-test.yml
@@ -10,9 +10,9 @@ jobs:
     name: Lint/Check/Test - Python ${{ matrix.python-version }} - ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,6 @@ jobs:
   draft_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         architecture: x64
     - run: pip install nox poetry
-    - run: nox --python 3.10
+    - run: nox --python 3.11
     - run: poetry build
     - run: poetry publish --username=__token__ --password=${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Updating various GH Actions:

- checkout@3 -> @4
- setup-python@3 -> @5
- codecov-action@3 -> @4
- release-drafter@5 -> @6

Release workflow now also runs on Python 3.11.